### PR TITLE
fix: link to raw banner image

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,4 +1,4 @@
-![The most reliable shipping solution](./banner.jpeg)
+![The most reliable shipping solution](https://raw.githubusercontent.com/EasyPost/.github/main/profile/banner.jpeg)
 
 ## EasyPost ❤️ Developer Experience
 


### PR DESCRIPTION
Links directly to the raw image on GitHub so it shows up correctly on GitHub.
